### PR TITLE
UI/group

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,6 +3,7 @@ import './App.css';
 import LoginRegisterForm from './LoginRegisterForm';
 import HomePage from './pages/home';
 import FriendsPage from './pages/friends';
+import GroupPage from './pages/groups/group';
 
 const router = createBrowserRouter([
   {
@@ -31,10 +32,11 @@ const router = createBrowserRouter([
     ],
   },
   {
-    path: '/group',
+    path: '/groups',
     children: [
       {
-        path: '/group/:groupId',
+        path: '/groups/:groupId',
+        element: <GroupPage />,
       },
     ],
   },

--- a/client/src/components/DropDownMenu.tsx
+++ b/client/src/components/DropDownMenu.tsx
@@ -1,11 +1,11 @@
 import {
   Children,
-  cloneElement,
   FC,
   HtmlHTMLAttributes,
+  MouseEvent,
+  MouseEventHandler,
   PropsWithChildren,
   ReactElement,
-  ReactNode,
   useEffect,
   useState,
 } from 'react';
@@ -13,16 +13,18 @@ import useDebounce from '../hooks/useDebounce';
 import { mergeClassNames } from '../utils';
 
 interface MenuProps extends PropsWithChildren {
-  triggerType: 'click' | 'hover';
+  triggerType?: 'click' | 'hover';
   asChild?: boolean;
   content: ReactElement;
+  className?: string;
 }
 
 const DropDownMenu: FC<MenuProps> = ({
   children,
-  triggerType,
+  triggerType = 'click',
   asChild = false,
   content,
+  className,
 }) => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
 
@@ -50,16 +52,24 @@ const DropDownMenu: FC<MenuProps> = ({
   };
 
   return (
-    <div
-      onClick={handleClick}
-      onMouseEnter={handleEnter}
-      onMouseLeave={handleLeave}
-      className={mergeClassNames(
-        'relative',
-        asChild ? '' : 'flex gap-2 hover:bg-secondary/50 rounded-lg p-2',
-      )}
-    >
-      {children}
+    <div className="relative">
+      <div
+        onClick={(e) => {
+          e.stopPropagation();
+          handleClick();
+        }}
+        onMouseEnter={handleEnter}
+        onMouseLeave={handleLeave}
+        className={mergeClassNames(
+          'relative',
+          asChild
+            ? ''
+            : 'flex justify-center items-center size-fit gap-2 hover:bg-secondary/50 rounded-lg p-2',
+          className,
+        )}
+      >
+        {children}
+      </div>
       {isOpen && content}
     </div>
   );
@@ -78,8 +88,8 @@ const DropDownMenuContent: FC<ContentProps> = ({
     <div
       {...props}
       className={mergeClassNames(
-        'flex gap-2 absolute top-[calc(100%+0.25rem)] left-0 mx-auto',
-        'bg-background p-2 border-border bodeer-solid border-2 rounded-lg',
+        'flex gap-2 absolute top-[calc(100%+0.25rem)] left-0',
+        'bg-background p-2 border-border border-solid border-2 rounded-lg w-fit',
         // 'invisible opacity-0 transition-opacity duration-300',
         layout == 'verticle' ? 'flex-col' : '',
         className,
@@ -98,7 +108,7 @@ const DropDownItem: FC<ItemProps> = ({ children, asChild }) => {
   return (
     <div
       className={mergeClassNames(
-        'rounded-lg',
+        'rounded-sm w-full text-nowrap',
         !asChild && 'p-2 hover:bg-secondary',
       )}
     >

--- a/client/src/components/PopupModal.tsx
+++ b/client/src/components/PopupModal.tsx
@@ -1,7 +1,57 @@
-import React from 'react';
+import { FC, PropsWithChildren, ReactNode, useState } from 'react';
+import { mergeClassNames } from '../utils';
 
-const PopupModal = () => {
-  return <div>PopupModal</div>;
+interface PopupModalProps extends PropsWithChildren {
+  widthPercent?: number;
+  heightPercent?: number;
+  className?: string;
+  backdropBlur?: Number;
+  modelRender: ReactNode;
+}
+
+const PopupModal: FC<PopupModalProps> = ({
+  widthPercent = 0.5,
+  heightPercent = 0.5,
+  className,
+  backdropBlur = 0,
+  modelRender,
+  children,
+}) => {
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+
+  return (
+    <>
+      <div
+        onClick={(e) => {
+          e.stopPropagation();
+          setIsOpen(true);
+        }}
+        className={mergeClassNames(className)}
+      >
+        {children}
+      </div>
+      {/* Popup */}
+      {isOpen && (
+        <div
+          onClick={(e) => {
+            e.stopPropagation();
+            setIsOpen(false);
+          }}
+          className="fixed top-0 left-0 w-svw h-svh flex justify-center items-center"
+        >
+          <div
+            style={{
+              width: `${widthPercent * 100}%`,
+              height: `${heightPercent * 100}%`,
+            }}
+            className=""
+          >
+            {modelRender}
+          </div>
+        </div>
+      )}
+    </>
+  );
 };
 
 export default PopupModal;

--- a/client/src/components/PopupModal.tsx
+++ b/client/src/components/PopupModal.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const PopupModal = () => {
+  return <div>PopupModal</div>;
+};
+
+export default PopupModal;

--- a/client/src/components/Post.tsx
+++ b/client/src/components/Post.tsx
@@ -1,6 +1,7 @@
 import {
   Angry,
   Edit,
+  Ellipsis,
   Heart,
   Laugh,
   LucideIcon,
@@ -22,7 +23,7 @@ import {
   DropDownMenuContent,
 } from './DropDownMenu';
 
-interface Props extends HTMLAttributes<HTMLDivElement> { }
+interface Props extends HTMLAttributes<HTMLDivElement> {}
 
 const Post: FC<Props> = ({ className }) => {
   const [isPopup, setIsPopup] = useState<boolean>(false);
@@ -38,7 +39,7 @@ const Post: FC<Props> = ({ className }) => {
         className={`flex flex-col gap-4 w-full h-fit p-4 my-4 border-border border-solid border-2 rounded-lg bg-card hover:bg-secondary/25 hover:cursor-pointer ${className}`}
       >
         {/* Author */}
-        <div className="flex gap-2">
+        <div className="flex gap-2 items-center">
           {/* TODO fix image */}
           <img
             className="rounded-full bg-gray-500 size-12"
@@ -55,7 +56,17 @@ const Post: FC<Props> = ({ className }) => {
             </p>
           </div>
           <div className="flex ml-auto">
-            <Edit className="text-primary" />
+            {/* <Edit className="text-primary" /> */}
+            <DropDownMenu
+              content={
+                <DropDownMenuContent className="-translate-x-1/2">
+                  <DropDownItem>Edit post</DropDownItem>
+                  <DropDownItem>History</DropDownItem>
+                </DropDownMenuContent>
+              }
+            >
+              <Ellipsis />
+            </DropDownMenu>
           </div>
         </div>
         {/* Content */}
@@ -196,11 +207,6 @@ const Reactions = () => {
   };
 
   return (
-    //   {/* <div className="flex gap-2"> */ }
-    // {/*   <ReactionButton color="#f7768e" amount={405} Icon={Heart} /> */ }
-    // {/*   <ReactionButton color="#e0af68" amount={32} Icon={Laugh} /> */ }
-    // {/*   <ReactionButton color="#f7768e" amount={1} Icon={Angry} /> */ }
-    // {/* </div> */ }
     <DropDownMenu
       triggerType="hover"
       content={
@@ -282,8 +288,8 @@ const ReactionButton: FC<ReactionBtnProps> = ({
 
   let activeStyle = isSelected
     ? ({
-      fill: color,
-    } as CSSProperties)
+        fill: color,
+      } as CSSProperties)
     : {};
 
   return (

--- a/client/src/components/PostCreationPanel.tsx
+++ b/client/src/components/PostCreationPanel.tsx
@@ -3,7 +3,7 @@ import { Globe, ChevronDown, Image } from 'lucide-react';
 const PostCreationPanel = () => {
   return (
     <div className="flex flex-col justify-start items-start border-border border-2 border-solid rounded-lg p-4 gap-4 w-full bg-card">
-      <div className="flex gap-4">
+      <div className="flex gap-4 w-full">
         {/* TODO fix image */}
         <img
           className="rounded-full bg-gray-500 size-16"

--- a/client/src/global.css
+++ b/client/src/global.css
@@ -55,6 +55,10 @@
   .base-input {
     @apply flex h-10 w-full rounded-md border border-input ring-ring bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50;
   }
+
+  .block-container {
+    @apply flex bg-background rounded-lg border-border border-solid border-2 p-4 gap-4;
+  }
 }
 
 body,

--- a/client/src/pages/groups/group/GroupPanel.tsx
+++ b/client/src/pages/groups/group/GroupPanel.tsx
@@ -1,5 +1,7 @@
 import { useParams } from 'react-router';
 import PostCreationPanel from '../../../components/PostCreationPanel';
+import { mergeClassNames } from '../../../utils';
+import PostsView from '../../../components/PostsView';
 
 const GroupPanel = () => {
   const params = useParams();
@@ -8,9 +10,43 @@ const GroupPanel = () => {
   console.log(groupId);
 
   return (
-    <div>
+    <div className="flex flex-col gap-4">
       {groupId}
+      <GroupHeader />
       <PostCreationPanel />
+      <PostsView data={null} />
+    </div>
+  );
+};
+
+const GroupHeader = () => {
+  return (
+    <div className="w-full">
+      <img
+        className="w-full object-cover rounded-lg h-40"
+        src="https://styles.redditmedia.com/t5_2sx2i/styles/bannerBackgroundImage_qhzusrmg7cl61.png?width=2176&frame=1&auto=webp&s=62cf20f42cbf8d32f8e4b9500fbf9cba08b1e3a8"
+        alt="group cover image"
+      />
+      <div className="relative flex gap-2 p-2">
+        {/* Avatar img container */}
+        <div className="h-0 min-w-fit">
+          <img
+            className={mergeClassNames(
+              'relative aspect-square rounded-full size-24 -translate-y-1/2',
+              'border-background border-solid border-4',
+            )}
+            src="https://styles.redditmedia.com/t5_2sx2i/styles/communityIcon_7fixeonxbxd41.png"
+            alt="group avatar"
+          />
+        </div>
+        {/* Group info */}
+        <div className="flex gap-2 w-full items-center">
+          <h1 className="font-bold text-2xl">g/Punixorn</h1>
+          <button className="px-4 py-2 ml-auto border-border border-solid border-2 rounded-lg bg-background hover:bg-secondary">
+            Joined
+          </button>
+        </div>
+      </div>
     </div>
   );
 };

--- a/client/src/pages/groups/group/GroupPanel.tsx
+++ b/client/src/pages/groups/group/GroupPanel.tsx
@@ -1,0 +1,18 @@
+import { useParams } from 'react-router';
+import PostCreationPanel from '../../../components/PostCreationPanel';
+
+const GroupPanel = () => {
+  const params = useParams();
+  const groupId = params.groupId;
+
+  console.log(groupId);
+
+  return (
+    <div>
+      {groupId}
+      <PostCreationPanel />
+    </div>
+  );
+};
+
+export default GroupPanel;

--- a/client/src/pages/groups/group/GroupRightSide.tsx
+++ b/client/src/pages/groups/group/GroupRightSide.tsx
@@ -1,6 +1,7 @@
-import { Globe, Mail, UserRound } from 'lucide-react';
+import { Check, Globe, Mail, Trash, UserRound } from 'lucide-react';
 import { mergeClassNames } from '../../../utils';
 import PopupModal from '../../../components/PopupModal';
+import { ReactElement, useState } from 'react';
 
 const GroupRightSide = () => {
   return (
@@ -67,7 +68,100 @@ const GroupRightSide = () => {
 };
 
 const Popup = () => {
-  return <div className="block-container flex-col size-full">sasas</div>;
+  const [selectedTab, setSelectedTab] = useState<number>(0);
+
+  const tabs: string[] = ['People', 'Requests'];
+  const tabNodes: ReactElement[] = [<ViewAllPeople />, <ViewRequests />];
+
+  return (
+    <div className="block-container flex-col size-full">
+      {/* Tab selection */}
+      <div className="flex">
+        {tabs.map((name, idx) => {
+          return (
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                setSelectedTab(idx);
+              }}
+              className={mergeClassNames(
+                'flex p-4 justify-center items-center w-full',
+                'hover:bg-secondary transition-colors rounded-tl-lg rounded-tr-lg border-border',
+                selectedTab == idx && 'border-b-2 border-solid',
+              )}
+              key={idx}
+            >
+              {name}
+            </button>
+          );
+        })}
+      </div>
+      {/* Content */}
+      {tabNodes[selectedTab]}
+    </div>
+  );
+};
+
+const ViewAllPeople = () => {
+  const data: string[] = ['as', 'asa', 'asasasasasa'];
+
+  console.log(data.length);
+
+  return (
+    <div className="flex flex-col gap-4 justify-start items-center size-full">
+      {data.length > 0 ? (
+        <>
+          {data.map((item, idx) => {
+            return (
+              <div key={idx} className="block-container w-full">
+                {item}
+              </div>
+            );
+          })}
+        </>
+      ) : (
+        <div className="flex justify-center items-center size-full">
+          No members here
+        </div>
+      )}
+    </div>
+  );
+};
+
+const ViewRequests = () => {
+  const data: string[] = ['Guria', 'Menege', 'Kaguya'];
+
+  console.log(data.length);
+
+  return (
+    <div className="flex flex-col gap-4 justify-start items-center size-full">
+      {data.length > 0 ? (
+        <>
+          {data.map((item, idx) => {
+            return (
+              <div key={idx} className="block-container w-full items-center">
+                Request from @{item}
+                <div className="flex gap-2 h-full ml-auto">
+                  <button className="flex justify-center items-center gap-2 py-2 px-4 bg-success rounded-lg">
+                    <Check />
+                    Accept
+                  </button>
+                  <button className="flex justify-center items-center gap-2 py-2 px-4 bg-danger rounded-lg">
+                    <Trash />
+                    Deny
+                  </button>
+                </div>
+              </div>
+            );
+          })}
+        </>
+      ) : (
+        <div className="flex justify-center items-center size-full">
+          No members here
+        </div>
+      )}
+    </div>
+  );
 };
 
 export default GroupRightSide;

--- a/client/src/pages/groups/group/GroupRightSide.tsx
+++ b/client/src/pages/groups/group/GroupRightSide.tsx
@@ -1,0 +1,45 @@
+import { Globe } from 'lucide-react';
+import { mergeClassNames } from '../../../utils';
+
+const GroupRightSide = () => {
+  return (
+    <div
+      className={mergeClassNames(
+        'flex flex-col p-4 gap-4',
+        'border-border border-2 border-solid rounded-lg',
+      )}
+    >
+      {/* Group Description */}
+      <div className="flex flex-col">
+        <h1 className="font-bold text-lg">
+          g/Punixorn - the home for cunny NIXXER!
+        </h1>
+        <p>
+          Submit screenshots of all your *NIX desktops, themes, and nifty
+          configurations, or submit anything else that will make ricers happy.
+          Maybe a server running on an Amiga, or a Thinkpad signed by Bjarne
+          Stroustrup? Show the world how pretty your computer can be!
+        </p>
+      </div>
+      {/* Visibility */}
+      <p className="flex gap-2 items-center justify-center font-semibold rounded-lg bg-secondary py-2">
+        <Globe size={24} /> Public group
+      </p>
+      {/* Members */}
+      <div className="flex gap-2">
+        <div className="flex flex-col w-full">
+          <h2 className="font-bold">487K</h2>
+          <p className="text-muted">Members</p>
+        </div>
+        <div className="flex flex-col w-full">
+          <h2 className="font-bold">911</h2>
+          <p className="text-muted flex gap-2 items-center">
+            <div className="size-2 bg-success rounded-full"></div> Online
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default GroupRightSide;

--- a/client/src/pages/groups/group/GroupRightSide.tsx
+++ b/client/src/pages/groups/group/GroupRightSide.tsx
@@ -1,45 +1,73 @@
-import { Globe } from 'lucide-react';
+import { Globe, Mail, UserRound } from 'lucide-react';
 import { mergeClassNames } from '../../../utils';
+import PopupModal from '../../../components/PopupModal';
 
 const GroupRightSide = () => {
   return (
-    <div
-      className={mergeClassNames(
-        'flex flex-col p-4 gap-4',
-        'border-border border-2 border-solid rounded-lg',
-      )}
-    >
-      {/* Group Description */}
-      <div className="flex flex-col">
-        <h1 className="font-bold text-lg">
-          g/Punixorn - the home for cunny NIXXER!
-        </h1>
-        <p>
-          Submit screenshots of all your *NIX desktops, themes, and nifty
-          configurations, or submit anything else that will make ricers happy.
-          Maybe a server running on an Amiga, or a Thinkpad signed by Bjarne
-          Stroustrup? Show the world how pretty your computer can be!
-        </p>
-      </div>
-      {/* Visibility */}
-      <p className="flex gap-2 items-center justify-center font-semibold rounded-lg bg-secondary py-2">
-        <Globe size={24} /> Public group
-      </p>
-      {/* Members */}
-      <div className="flex gap-2">
-        <div className="flex flex-col w-full">
-          <h2 className="font-bold">487K</h2>
-          <p className="text-muted">Members</p>
-        </div>
-        <div className="flex flex-col w-full">
-          <h2 className="font-bold">911</h2>
-          <p className="text-muted flex gap-2 items-center">
-            <div className="size-2 bg-success rounded-full"></div> Online
+    <div className="flex flex-col gap-4">
+      <div className={mergeClassNames('block-container flex-col')}>
+        {/* Group Description */}
+        <div className="flex flex-col">
+          <h1 className="font-bold text-lg">
+            g/Punixorn - the home for cunny NIXXER!
+          </h1>
+          <p>
+            Submit screenshots of all your *NIX desktops, themes, and nifty
+            configurations, or submit anything else that will make ricers happy.
+            Maybe a server running on an Amiga, or a Thinkpad signed by Bjarne
+            Stroustrup? Show the world how pretty your computer can be!
           </p>
         </div>
+        {/* Visibility */}
+        <p className="flex gap-2 items-center justify-center font-semibold rounded-lg bg-secondary py-2">
+          <Globe size={24} /> Public group
+        </p>
+        {/* Members */}
+        <div className="flex gap-2">
+          <div className="flex flex-col w-full">
+            <h2 className="font-bold">487K</h2>
+            <p className="text-muted">Members</p>
+          </div>
+          <div className="flex flex-col w-full">
+            <h2 className="font-bold">911</h2>
+            <p className="text-muted flex gap-2 items-center">
+              <div className="size-2 bg-success rounded-full"></div> Online
+            </p>
+          </div>
+        </div>
+      </div>
+      {/* Current role */}
+      <div className="block-container">
+        <img
+          className="rounded-full bg-gray-500 size-12"
+          src="https://preview.redd.it/lhxag30v58d31.jpg?width=640&crop=smart&auto=webp&s=bcf582e90ffb150dfd3f905fbfbe44deb30e56e6"
+          alt="User avatar"
+        />
+        <div className="flex flex-col justify-center items-start">
+          <h1 className="text-xl font-semibold">Admin</h1>
+        </div>
+      </div>
+      {/* Actions */}
+      <div className="block-container flex-col">
+        <PopupModal
+          heightPercent={0.8}
+          className="w-full"
+          modelRender={<Popup />}
+        >
+          <button className="flex gap-2 w-full items-center justify-center font-semibold rounded-lg bg-primary text-foreground py-2">
+            <UserRound size={24} /> People
+          </button>
+        </PopupModal>
+        <button className="flex gap-2 w-full items-center justify-center font-semibold rounded-lg bg-primary text-foreground py-2">
+          <Mail size={24} /> Requests
+        </button>
       </div>
     </div>
   );
+};
+
+const Popup = () => {
+  return <div className="block-container flex-col size-full">sasas</div>;
 };
 
 export default GroupRightSide;

--- a/client/src/pages/groups/group/index.tsx
+++ b/client/src/pages/groups/group/index.tsx
@@ -1,9 +1,10 @@
 import Layout from '../../../components/Layout';
 import GroupPanel from './GroupPanel';
+import GroupRightSide from './GroupRightSide';
 
 const GroupPage = () => {
   return (
-    <Layout stickyRightSideCmp={<></>}>
+    <Layout stickyRightSideCmp={<GroupRightSide />}>
       <GroupPanel />
     </Layout>
   );

--- a/client/src/pages/groups/group/index.tsx
+++ b/client/src/pages/groups/group/index.tsx
@@ -1,0 +1,12 @@
+import Layout from '../../../components/Layout';
+import GroupPanel from './GroupPanel';
+
+const GroupPage = () => {
+  return (
+    <Layout stickyRightSideCmp={<></>}>
+      <GroupPanel />
+    </Layout>
+  );
+};
+
+export default GroupPage;


### PR DESCRIPTION
- DropdownElement
  - Fix where clicking dropdown trigger also trigger the underlyig element as well (stopPropagation)
  - Fix styling where text wrap
 
- GroupPage
  - Group page now lie at url /groups/:groupId
  - Added GroupHeader: show cover and avatar images as well as group name and whether has joined the group or not
  - Added right bar fro group:
    - Show group description
    - Show total members
    - Show online members in group (For aethestic only)

- Posts
  - Edit icon is changed to dropdown menu:
    - Now show 2 options instead: `Edit post` and `edit history`

https://github.com/user-attachments/assets/12ae9baa-f073-4c00-a522-ced2eb427760

